### PR TITLE
Added Cancel All Orders function

### DIFF
--- a/buda.js
+++ b/buda.js
@@ -121,6 +121,11 @@ Buda.prototype.order_book = function(market) {
   return this._request('GET','/api/v2/markets/'+market+'/order_book');
 }
 
+// https://api.buda.com/#rest-api-llamadas-publicas-volumen-transado
+Buda.prototype.volume = function(market) {
+  return this._request('GET','/api/v2/markets/'+market+'/volume');
+}
+
 // https://api.buda.com/#trades
 Buda.prototype.trades = function(market, timestamp, limit) {
 	var payload = { 

--- a/buda.js
+++ b/buda.js
@@ -197,6 +197,15 @@ Buda.prototype.cancel_order = function(order_id) {
   return this._request('PUT','/api/v2/orders/'+order_id,null,payload,true);
 }
 
+// https://api.buda.com/#rest-api-llamadas-privadas-cancelar-todas-mis-ordenes
+Buda.prototype.cancel_orders = function(market, type) {
+	var payload={
+    market: market,
+    type: type
+  }
+  return this._request('DELETE','/api/v2/orders',null,payload,true);
+}
+
 // https://api.buda.com/#estado-de-la-orden
 Buda.prototype.single_order = function(order_id) {
   return this._request('GET','/api/v2/orders/'+order_id,null,null,true);

--- a/buda.js
+++ b/buda.js
@@ -122,8 +122,12 @@ Buda.prototype.order_book = function(market) {
 }
 
 // https://api.buda.com/#trades
-Buda.prototype.trades = function(market, timestamp) {
-  return this._request('GET','/api/v2/markets/'+market+'/trades',{timestamp: timestamp});
+Buda.prototype.trades = function(market, timestamp, limit) {
+	var payload = { 
+    timestamp: timestamp,
+    limit: limit
+  };
+  return this._request('GET','/api/v2/markets/'+market+'/trades',payload);
 }
 
 // https://api.buda.com/#markets

--- a/example.js
+++ b/example.js
@@ -20,6 +20,7 @@ var privateBuda = new Buda(api_key, api_secret);
 //privateBuda.order_pages('btc-clp').then(function(result) { console.log(result) });
 //privateBuda.new_order("btc-clp", "bid", "limit", 835875, 0.05).then(function(result) { console.log(result) });
 //privateBuda.cancel_order(3262406).then(function(result) { console.log(result) });
+//privateBuda.cancel_orders('btc-clp','bid').then(function(result) { console.log(result) });
 //privateBuda.single_order(588).then(function(result) { console.log(result) });
 //privateBuda.deposits('clp').then(function(result) { console.log(result) });
 //privateBuda.withdrawals('clp').then(function(result) { console.log(result) });


### PR DESCRIPTION
Added function to handle canceling all orders at once according to the new Buda endpoint, with options for deleting all by `market` and `type`.
https://api.buda.com/#rest-api-llamadas-privadas-cancelar-todas-mis-ordenes